### PR TITLE
#8  - 댓글 CRD 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -38,6 +38,10 @@ dependencies {
 	implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.0'
 	implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
+++ b/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
@@ -11,7 +11,7 @@ import site.moasis.monolithicbe.domain.comment.service.CommentWriteService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/comments")
+@RequestMapping("/api/comments")
 @Tag(name = "CommentController", description = "댓글을 각 속성 값으로 조회 하고 생성, 삭제 가능하다")
 public class CommentController {
 
@@ -20,33 +20,33 @@ public class CommentController {
 
     @GetMapping("/id/{commentId}")
     @Operation(summary = "id를 통한 댓글 단건 조회")
-    public CommentDto.commentOneDto retrieveComment(@PathVariable Long commentId){
-        return readService.retrieveCommentById(commentId);
+    public CommonResponse<?> retrieveComment(@PathVariable Long commentId){
+        return CommonResponse.success(readService.retrieveCommentById(commentId));
     }
 
     @GetMapping("/user/{userId}")
     @Operation(summary = "user_id를 통한 댓글 조회")
-    public CommentDto.commentResponseDto retrieveCommentsByUserId(@PathVariable Long userId){
-        return readService.retrieveCommentByUserId(userId);
+    public CommonResponse<?> retrieveCommentsByUserId(@PathVariable Long userId){
+        return CommonResponse.success(readService.retrieveCommentByUserId(userId));
     }
 
     @GetMapping("/article/{articleId}")
     @Operation(summary = "article_id를 통한 댓글 조회")
-    public CommentDto.commentResponseDto retrieveCommentsByArticleId(@PathVariable Long articleId){
-        return readService.retrieveCommentByArticleId(articleId);
+    public CommonResponse<?> retrieveCommentsByArticleId(@PathVariable Long articleId){
+        return CommonResponse.success(readService.retrieveCommentByArticleId(articleId));
     }
 
     @PostMapping("/")
     @Operation(summary = "댓글 생성")
-    public CommonResponse<String> createComment(CommentDto.commentCreateDto dto){
-        writeService.createComment(dto);
+    public CommonResponse<?> createComment(CommentDto.commentCreateDto commentCreateDto){
+        writeService.createComment(commentCreateDto);
         return CommonResponse.success("댓글 생성 완료");
     }
 
-    @PostMapping("/delete")
+    @PostMapping("/id/{commentId}")
     @Operation(summary = "id를 통한 댓글 삭제")
-    public CommonResponse<?> deleteComment(Long id){
-        writeService.deleteComment(id);
+    public CommonResponse<?> deleteComment(@PathVariable Long commentId){
+        writeService.deleteComment(commentId);
         return CommonResponse.success("댓글 삭제 완료");
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
+++ b/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
@@ -5,13 +5,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import site.moasis.monolithicbe.common.response.CommonResponse;
-import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
 import site.moasis.monolithicbe.domain.comment.service.CommentReadService;
 import site.moasis.monolithicbe.domain.comment.service.CommentWriteService;
 
+import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentCreateDto;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/comments")
+@RequestMapping("/v1/api/comments")
 @Tag(name = "CommentController", description = "댓글을 각 속성 값으로 조회 하고 생성, 삭제 가능하다")
 public class CommentController {
 
@@ -38,7 +39,7 @@ public class CommentController {
 
     @PostMapping("/id")
     @Operation(summary = "댓글 생성")
-    public CommonResponse<?> createComment(CommentDto.commentCreateDto commentCreateDto){
+    public CommonResponse<?> createComment(CommentCreateDto commentCreateDto){
         writeService.createComment(commentCreateDto);
         return CommonResponse.success("댓글 생성 완료");
     }

--- a/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
+++ b/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
@@ -1,0 +1,52 @@
+package site.moasis.monolithicbe.application.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import site.moasis.monolithicbe.common.response.CommonResponse;
+import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
+import site.moasis.monolithicbe.domain.comment.service.CommentReadService;
+import site.moasis.monolithicbe.domain.comment.service.CommentWriteService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+@Tag(name = "CommentController", description = "댓글을 각 속성 값으로 조회 하고 생성, 삭제 가능하다")
+public class CommentController {
+
+    private final CommentReadService readService;
+    private final CommentWriteService writeService;
+
+    @GetMapping("/id/{commentId}")
+    @Operation(summary = "id를 통한 댓글 단건 조회")
+    public CommentDto.commentOneDto retrieveComment(@PathVariable Long commentId){
+        return readService.retrieveCommentById(commentId);
+    }
+
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "user_id를 통한 댓글 조회")
+    public CommentDto.commentResponseDto retrieveCommentsByUserId(@PathVariable Long userId){
+        return readService.retrieveCommentByUserId(userId);
+    }
+
+    @GetMapping("/article/{articleId}")
+    @Operation(summary = "article_id를 통한 댓글 조회")
+    public CommentDto.commentResponseDto retrieveCommentsByArticleId(@PathVariable Long articleId){
+        return readService.retrieveCommentByArticleId(articleId);
+    }
+
+    @PostMapping("/")
+    @Operation(summary = "댓글 생성")
+    public CommonResponse<String> createComment(CommentDto.commentCreateDto dto){
+        writeService.createComment(dto);
+        return CommonResponse.success("댓글 생성 완료");
+    }
+
+    @PostMapping("/delete")
+    @Operation(summary = "id를 통한 댓글 삭제")
+    public CommonResponse<?> deleteComment(Long id){
+        writeService.deleteComment(id);
+        return CommonResponse.success("댓글 삭제 완료");
+    }
+}

--- a/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
+++ b/src/main/java/site/moasis/monolithicbe/application/controller/CommentController.java
@@ -3,6 +3,8 @@ package site.moasis.monolithicbe.application.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.moasis.monolithicbe.common.response.CommonResponse;
 import site.moasis.monolithicbe.domain.comment.service.CommentReadService;
@@ -12,42 +14,82 @@ import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentCrea
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/api/comments")
+@RequestMapping("api/v1/comments")
 @Tag(name = "CommentController", description = "댓글을 각 속성 값으로 조회 하고 생성, 삭제 가능하다")
 public class CommentController {
 
     private final CommentReadService readService;
     private final CommentWriteService writeService;
 
-    @GetMapping("/id/{commentId}")
-    @Operation(summary = "id를 통한 댓글 단건 조회")
-    public CommonResponse<?> retrieveComment(@PathVariable Long commentId){
-        return CommonResponse.success(readService.retrieveCommentById(commentId));
+    @GetMapping
+    @Operation(summary = "댓글 전체 조회")
+    public ResponseEntity<CommonResponse<?>> findAll(){
+        var commentInfo = readService.selectAll();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(commentInfo, "전체 댓글 조회 성공"));
     }
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/{commentId}")
+    @Operation(summary = "댓글 단건 조회")
+    public ResponseEntity<CommonResponse<?>> findOne(@PathVariable Long commentId){
+        var commentInfo = readService.selectOne(commentId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(commentInfo, "댓글 조회 성공"));
+    }
+
+    @GetMapping("/users/{userId}")
     @Operation(summary = "user_id를 통한 댓글 조회")
-    public CommonResponse<?> retrieveCommentsByUserId(@PathVariable Long userId){
-        return CommonResponse.success(readService.retrieveCommentByUserId(userId));
+    public ResponseEntity<CommonResponse<?>> findByUser(@PathVariable Long userId){
+        var commentInfo = readService.selectByUser(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(commentInfo, "Id가 " + userId + "인 유저가 작성한 댓글 조회 성공"));
     }
 
-    @GetMapping("/article/{articleId}")
+    @GetMapping("/articles/{articleId}")
     @Operation(summary = "article_id를 통한 댓글 조회")
-    public CommonResponse<?> retrieveCommentsByArticleId(@PathVariable Long articleId){
-        return CommonResponse.success(readService.retrieveCommentByArticleId(articleId));
+    public ResponseEntity<CommonResponse<?>> findByArticle(@PathVariable Long articleId){
+        var commentInfo = readService.selectByArticle(articleId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(commentInfo, articleId + "번 게시글 댓글 조회 성공"));
     }
 
-    @PostMapping("/id")
+    @PostMapping
     @Operation(summary = "댓글 생성")
-    public CommonResponse<?> createComment(CommentCreateDto commentCreateDto){
-        writeService.createComment(commentCreateDto);
-        return CommonResponse.success("댓글 생성 완료");
+    public ResponseEntity<CommonResponse<?>>createOne(@RequestBody CommentCreateDto commentCreateDto){
+        var commentInfo = writeService.insertOne(commentCreateDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CommonResponse.success(null, commentInfo + "번 댓글 생성 완료"));
     }
 
     @PostMapping("/id/{commentId}")
     @Operation(summary = "id를 통한 댓글 삭제")
-    public CommonResponse<?> deleteComment(@PathVariable Long commentId){
-        writeService.deleteComment(commentId);
-        return CommonResponse.success("댓글 삭제 완료");
+    public ResponseEntity<CommonResponse<?>> deleteOne(@PathVariable Long commentId){
+        var commentInfo = writeService.dropOne(commentId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(null, commentInfo + "번 댓글 삭제 완료"));
+    }
+
+    @PostMapping("/user/{userId}")
+    @Operation(summary = "해당 user가 작성한 댓글 삭제")
+    public ResponseEntity<CommonResponse<?>> deleteByUser(@PathVariable Long userId){
+        var commentInfo = writeService.dropByUser(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(null, "Id가 " + commentInfo + "인 유저가 작성한 댓글 삭제 성공"));
+    }
+
+    @PostMapping("/article/{articleId}")
+    @Operation(summary = "해당 article에 속한 댓글 삭제")
+    public ResponseEntity<CommonResponse<?>> deleteByArticle(@PathVariable Long articleId){
+        var articleInfo = writeService.dropByArticle(articleId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.success(null, articleInfo + "번 게시물의 댓글 삭제 성공"));
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/common/response/CommonControllerAdvice.java
+++ b/src/main/java/site/moasis/monolithicbe/common/response/CommonControllerAdvice.java
@@ -33,6 +33,7 @@ public class CommonControllerAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = Exception.class)
     public CommonResponse onException(Exception e) {
+        log.warn("[INTERNAL_SERVER_ERROR] errorMsg = {}",  NestedExceptionUtils.getMostSpecificCause(e).getMessage());
         return CommonResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR);
     }
 

--- a/src/main/java/site/moasis/monolithicbe/common/response/ErrorCode.java
+++ b/src/main/java/site/moasis/monolithicbe/common/response/ErrorCode.java
@@ -9,11 +9,7 @@ public enum ErrorCode {
     COMMON_SYSTEM_ERROR("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."), // 장애 상황
     COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
-    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다."),
-
-    // GIFT
-    GIFT_NOT_RECEIVABLE_CONDITION("선물 수락이 가능한 상태가 아닙니다."),
-    GIFT_NOT_MODIFY_DELIVERY_CONDITION("배송지 변경이 가능한 상태가 아닙니다.");
+    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다.");
 
     private final String errorMsg;
 

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
@@ -5,12 +5,12 @@ import site.moasis.monolithicbe.domain.comment.entity.Comment;
 import java.util.*;
 
 public class CommentDto {
-    public record commentCreateDto(String content, Long articleId, Long userId) {
+    public static record CommentCreateDto(String content, Long articleId, Long userId) {
     }
 
-    public record commentOneDto(Optional<Comment> comment) {
+    public static record CommentOneDto(Optional<Comment> comment) {
     }
 
-    public record commentResponseDto(List<Comment> commentList) {
+    public static record CommentResponseDto(List<Comment> commentList) {
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
@@ -5,12 +5,12 @@ import site.moasis.monolithicbe.domain.comment.entity.Comment;
 import java.util.*;
 
 public class CommentDto {
-    public static record CommentCreateDto(String content, Long articleId, Long userId) {
+    public record CommentCreateDto(String content, Long articleId, Long userId) {
     }
 
-    public static record CommentOneDto(Optional<Comment> comment) {
+    public record CommentOneDto(Optional<Comment> comment) {
     }
 
-    public static record CommentResponseDto(List<Comment> commentList) {
+    public record CommentResponseDto(List<Comment> comments) {
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/dto/CommentDto.java
@@ -1,4 +1,16 @@
 package site.moasis.monolithicbe.domain.comment.dto;
 
-public record CommentDto() {
+import site.moasis.monolithicbe.domain.comment.entity.Comment;
+
+import java.util.*;
+
+public class CommentDto {
+    public record commentCreateDto(String content, Long articleId, Long userId) {
+    }
+
+    public record commentOneDto(Optional<Comment> comment) {
+    }
+
+    public record commentResponseDto(List<Comment> commentList) {
+    }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/entity/Comment.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/entity/Comment.java
@@ -1,4 +1,20 @@
 package site.moasis.monolithicbe.domain.comment.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Comment {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String content;
+    private Long articleId;
+    private Long userId;
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/repository/CommentRepository.java
@@ -1,4 +1,13 @@
 package site.moasis.monolithicbe.domain.comment.repository;
 
-public class CommentRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNullApi;
+import site.moasis.monolithicbe.domain.comment.entity.Comment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByArticleId(Long articleId);
+    List<Comment> findByUserId(Long userId);
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,6 @@
 package site.moasis.monolithicbe.domain.comment.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.lang.NonNullApi;
 import site.moasis.monolithicbe.domain.comment.entity.Comment;
 
 import java.util.List;
@@ -10,4 +9,6 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleId(Long articleId);
     List<Comment> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+    void deleteByArticleId(Long articleId);
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
 import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
 import java.util.Optional;
-
 import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentResponseDto;
 import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentOneDto;
 
@@ -17,16 +16,22 @@ public class CommentReadService{
 
     private final CommentRepository commentRepository;
 
-    public CommentOneDto retrieveCommentById(Long commentId){
+    public CommentResponseDto selectAll(){
+        return new CommentResponseDto(commentRepository.findAll());
+    }
+
+    public CommentOneDto selectOne(Long commentId){
         return new CommentOneDto(
                 Optional.ofNullable(commentRepository.findById(commentId)
                         .orElseThrow(EntityNotFoundException::new)));
     }
-    public CommentResponseDto retrieveCommentByArticleId(Long articleId){
+
+    public CommentResponseDto selectByArticle(Long articleId){
         return new CommentResponseDto(
                 commentRepository.findByArticleId(articleId));
     }
-    public CommentResponseDto retrieveCommentByUserId(Long userId){
+
+    public CommentResponseDto selectByUser(Long userId){
         return new CommentResponseDto(
                 commentRepository.findByUserId(userId));
     }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
@@ -4,12 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
-import site.moasis.monolithicbe.common.response.ErrorCode;
 import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
-import site.moasis.monolithicbe.domain.comment.entity.Comment;
 import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -20,18 +17,16 @@ public class CommentReadService{
     private final CommentRepository commentRepository;
 
     public CommentDto.commentOneDto retrieveCommentById(Long commentId){
-        return toDto(Optional.ofNullable(commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new)));
+        return new CommentDto.commentOneDto(
+                Optional.ofNullable(commentRepository.findById(commentId)
+                        .orElseThrow(EntityNotFoundException::new)));
     }
     public CommentDto.commentResponseDto retrieveCommentByArticleId(Long articleId){
-        return toDto(commentRepository.findByArticleId(articleId));
+        return new CommentDto.commentResponseDto(
+                commentRepository.findByArticleId(articleId));
     }
     public CommentDto.commentResponseDto retrieveCommentByUserId(Long userId){
-        return toDto(commentRepository.findByUserId(userId));
-    }
-    public CommentDto.commentResponseDto toDto(List<Comment> commentList){
-        return new CommentDto.commentResponseDto(commentList);
-    }
-    public CommentDto.commentOneDto toDto(Optional<Comment> comment){
-        return new CommentDto.commentOneDto(comment);
+        return new CommentDto.commentResponseDto(
+                commentRepository.findByUserId(userId));
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
@@ -4,10 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
-import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
 import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
-
 import java.util.Optional;
+
+import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentResponseDto;
+import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentOneDto;
 
 @Service
 @RequiredArgsConstructor
@@ -16,17 +17,17 @@ public class CommentReadService{
 
     private final CommentRepository commentRepository;
 
-    public CommentDto.commentOneDto retrieveCommentById(Long commentId){
-        return new CommentDto.commentOneDto(
+    public CommentOneDto retrieveCommentById(Long commentId){
+        return new CommentOneDto(
                 Optional.ofNullable(commentRepository.findById(commentId)
                         .orElseThrow(EntityNotFoundException::new)));
     }
-    public CommentDto.commentResponseDto retrieveCommentByArticleId(Long articleId){
-        return new CommentDto.commentResponseDto(
+    public CommentResponseDto retrieveCommentByArticleId(Long articleId){
+        return new CommentResponseDto(
                 commentRepository.findByArticleId(articleId));
     }
-    public CommentDto.commentResponseDto retrieveCommentByUserId(Long userId){
-        return new CommentDto.commentResponseDto(
+    public CommentResponseDto retrieveCommentByUserId(Long userId){
+        return new CommentResponseDto(
                 commentRepository.findByUserId(userId));
     }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentReadService.java
@@ -1,4 +1,37 @@
 package site.moasis.monolithicbe.domain.comment.service;
 
-public class CommentReadService {
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
+import site.moasis.monolithicbe.common.response.ErrorCode;
+import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
+import site.moasis.monolithicbe.domain.comment.entity.Comment;
+import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentReadService{
+
+    private final CommentRepository commentRepository;
+
+    public CommentDto.commentOneDto retrieveCommentById(Long commentId){
+        return toDto(Optional.ofNullable(commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new)));
+    }
+    public CommentDto.commentResponseDto retrieveCommentByArticleId(Long articleId){
+        return toDto(commentRepository.findByArticleId(articleId));
+    }
+    public CommentDto.commentResponseDto retrieveCommentByUserId(Long userId){
+        return toDto(commentRepository.findByUserId(userId));
+    }
+    public CommentDto.commentResponseDto toDto(List<Comment> commentList){
+        return new CommentDto.commentResponseDto(commentList);
+    }
+    public CommentDto.commentOneDto toDto(Optional<Comment> comment){
+        return new CommentDto.commentOneDto(comment);
+    }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
@@ -4,17 +4,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
-import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
 import site.moasis.monolithicbe.domain.comment.entity.Comment;
 import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
 
+import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentCreateDto;
+
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class CommentWriteService{
 
     private final CommentRepository commentRepository;
 
-    public void createComment(CommentDto.commentCreateDto commentCreateDto){
+    public void createComment(CommentCreateDto commentCreateDto){
         Comment commentEntity = Comment.builder()
                 .content(commentCreateDto.content())
                 .articleId(commentCreateDto.articleId())
@@ -23,7 +25,6 @@ public class CommentWriteService{
         commentRepository.save(commentEntity);
     }
 
-    @Transactional
     public void deleteComment(Long commentId){
         commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
         commentRepository.deleteById(commentId);

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
@@ -1,4 +1,31 @@
 package site.moasis.monolithicbe.domain.comment.service;
 
-public class CommentWriteService {
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
+import site.moasis.monolithicbe.domain.comment.dto.CommentDto;
+import site.moasis.monolithicbe.domain.comment.entity.Comment;
+import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentWriteService{
+
+    private final CommentRepository commentRepository;
+
+    public void createComment(CommentDto.commentCreateDto commentCreateDto){
+        Comment commentEntity = Comment.builder()
+                .content(commentCreateDto.content())
+                .articleId(commentCreateDto.articleId())
+                .userId(commentCreateDto.userId())
+                .build();
+        commentRepository.save(commentEntity);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId){
+        commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
+        commentRepository.deleteById(commentId);
+    }
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/comment/service/CommentWriteService.java
@@ -1,6 +1,7 @@
 package site.moasis.monolithicbe.domain.comment.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.moasis.monolithicbe.common.exception.EntityNotFoundException;
@@ -9,6 +10,7 @@ import site.moasis.monolithicbe.domain.comment.repository.CommentRepository;
 
 import static site.moasis.monolithicbe.domain.comment.dto.CommentDto.CommentCreateDto;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -16,17 +18,29 @@ public class CommentWriteService{
 
     private final CommentRepository commentRepository;
 
-    public void createComment(CommentCreateDto commentCreateDto){
-        Comment commentEntity = Comment.builder()
+    public Long insertOne(CommentCreateDto commentCreateDto){
+        var commentEntity = Comment.builder()
                 .content(commentCreateDto.content())
                 .articleId(commentCreateDto.articleId())
                 .userId(commentCreateDto.userId())
                 .build();
         commentRepository.save(commentEntity);
+        return commentEntity.getId();
     }
 
-    public void deleteComment(Long commentId){
+    public Long dropOne(Long commentId){
         commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
         commentRepository.deleteById(commentId);
+        return commentId;
+    }
+
+    public Long dropByUser(Long userId) {
+        commentRepository.deleteByUserId(userId);
+        return userId;
+    }
+
+    public Long dropByArticle(Long articleId) {
+        commentRepository.deleteByArticleId(articleId);
+        return articleId;
     }
 }


### PR DESCRIPTION
### 구현

- JPA와 Springdoc-UI 의존성 추가
- id를 통해 댓글 단건 조회, 유저별/게시물별 다중 조회가 가능하도록 함
- Dto를 요청해 댓글을 생성하고 PK로 삭제할 수 있도록 함

### 제한사항

- 아직 SecurityConfig가 정의되지 않아 권한 요청하는 로직은 제외, 추후 ADMIN권한을 통해 댓글을 지우고 Authentication을 확인해 본인의 댓글을 지울 수 있는 기능을 추가해야함
- 댓글 단건 조회 또는 댓글 삭제 시 PK에 해당하는 값이 존재하지 않으면 EntityNotFoundException을 반환하도록 함. List반환 시에는 빈 리스트를 반환
- Article과의 join연산 시에 동적 쿼리를 생성하기 위해 Querydsl 의존성을 추가 하려고 했지만 프로젝트 내에서 QClass를 인식하지 못하는 issue가 발생, 이 부분을 더 연구 해보고 제한 될 시 JPQL을 사용
- BaseEntity를 상속해 엔티티의 생성 정보를 받아와야 함( ( )->찬도 )

1. CommentController
    
    ```java
    @GetMapping("/id/{commentId}")@Operation(summary = "id를 통한 댓글 단건 조회")
    public CommentDto.commentOneDto retrieveComment(@PathVariable Long commentId);
    
    @GetMapping("/users/{userId}")@Operation(summary = "user_id를 통한 댓글 조회")
    public CommentDto.commentResponseDto retrieveCommentsByUserId(@PathVariable Long userId);
    
    @GetMapping("/articles/{articleId}")@Operation(summary = "article_id를 통한 댓글 조회")
    public CommentDto.commentResponseDto retrieveCommentsByArticleId(@PathVariable Long articleId);
    
    @PostMapping("/")@Operation(summary = "댓글 생성")
    public CommonResponse<String> createComment(CommentCreateDto dto);
    
    @PostMapping("/id/{commentId}")@Operation(summary = "id를 통한 댓글 삭제")
    public CommonResponse<?> deleteComment(Long id);
    ```
    
2. Service
    1. CommentReadService
       - Retrieve Method 
    2. CommentWriteService
       - Create, Delete Method 
4. CommentRepository(JpaRepository)
  ```java
    Optional<Comment> findById(Long id);
    List<Comment> findByArticleId(Long articleId);
    List<Comment> findByUserId(Long userId);
    void deleteById(Long id);
  ```

<ul>
<li>Dto 사용 방식은 Outer Class - Inner Record 형식</li>
<li>메소드 사이 엔터 컨벤션 지키기</li>
<li>컨트롤러의 메소드명 : use-case에서 사용 되는 동사를 활용</li>
</ul>


조회 | 수정 | 생성 | 삭제
-- | -- | -- | --
findOne | modifyOne | createOne | deleteOne
findBy | modifyBy | createBy | deleteBy
findAll | modifiyAll | - | -

<ul>
<li>서비스의 메소드명 : DDL, DML에서 사용되는 명령어를 활용</li>
</ul>


조회 | 수정 | 생성 | 삭제
-- | -- | -- | --
selectOne | updateOne | insertOne | dropOne
selectBy | updateBy | insertBy | dropBy
selectAll | updateAll | - | - |