### PR TITLE
#26 Mail, Jwt 설정 변경 및 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-        id 'java'
-        id 'org.springframework.boot' version '3.0.1'
-        id 'io.spring.dependency-management' version '1.1.0'
-        id 'com.palantir.docker' version '0.34.0'
-        id 'com.palantir.docker-run' version '0.34.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.0.1'
+    id 'io.spring.dependency-management' version '1.1.0'
+    id 'com.palantir.docker' version '0.34.0'
+    id 'com.palantir.docker-run' version '0.34.0'
 }
 
 group = 'site.moasis'
@@ -11,77 +11,105 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
-        compileOnly {
-            extendsFrom annotationProcessor
-        }
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-        mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-        implementation 'org.springframework.boot:spring-boot-starter-security'
-        implementation 'org.springframework.boot:spring-boot-starter-validation'
-        implementation 'org.springframework.boot:spring-boot-starter-web'
-        implementation 'com.google.guava:guava:28.2-jre'
-        implementation 'org.apache.commons:commons-lang3:3.9'
-        implementation 'org.springframework.boot:spring-boot-starter-mail'
-        compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
-        compileOnly 'org.projectlombok:lombok'
-        runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-        annotationProcessor 'org.projectlombok:lombok'
-        testImplementation 'org.springframework.boot:spring-boot-starter-test'
-        implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-        implementation 'org.springframework.security:spring-security-oauth2-core:5.7.3'
-        implementation 'org.springframework.security:spring-security-oauth2-client'
-        implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-        implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-  
-        // testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.google.guava:guava:28.2-jre'
+    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'org.springframework.security:spring-security-oauth2-core:5.7.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-        // DB
-        runtimeOnly 'com.h2database:h2'
-        implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.0'
-        implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
-        implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    // ConfigurationProperties
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-	// for StringUtils
-	implementation 'org.apache.commons:commons-lang3:3.12.0'
-	implementation 'org.apache.commons:commons-text:1.9'
+    // Servlet
+    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
 
-	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.0'
+    // Guava Library
+    implementation 'com.google.guava:guava:28.2-jre'
 
-        // MapStruct
-        annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
-        implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    // Apache common lang : StringUtils
+    implementation 'org.apache.commons:commons-lang3:3.9'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Security
+    implementation 'org.springframework.security:spring-security-oauth2-core:5.7.3'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // DB
+    implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+    // H2
+    runtimeOnly 'com.h2database:h2'
+
+    // Maria
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.0'
+
+    // for StringUtils
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.apache.commons:commons-text:1.9'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.0'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 tasks.named('test') {
-        useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 jar {
-        enabled = false
+    enabled = false
 }
 
 String dockerHubUsernameProperty = findProperty('dockerHubUsername') ?: 'chung1306'
 String imageName = "${dockerHubUsernameProperty}/monolithic-be:$version"
 
 docker {
-        name imageName
-        files "build/libs/${bootJar.archiveFileName.get()}"
-        buildArgs([JAR_FILE: bootJar.archiveFileName.get()])
+    name imageName
+    files "build/libs/${bootJar.archiveFileName.get()}"
+    buildArgs([JAR_FILE: bootJar.archiveFileName.get()])
 }
 
 dockerRun {
-        name project.name
-        image imageName
-        ports '8080:8080'
-        clean true
-        daemonize true
-        arguments '--network=monolithic-be_moasis-net'
+    name project.name
+    image imageName
+    ports '8080:8080'
+    clean true
+    daemonize true
+    arguments '--network=monolithic-be_moasis-net'
 }

--- a/src/main/java/site/moasis/monolithicbe/configuration/AppProperties.java
+++ b/src/main/java/site/moasis/monolithicbe/configuration/AppProperties.java
@@ -1,0 +1,43 @@
+package site.moasis.monolithicbe.configuration;
+
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+
+    private final Mail mail = new Mail();
+    private final Jwt jwt = new Jwt();
+
+    @Data
+    public static class Mail{
+        private String protocol;
+        private String value;
+        private String host;
+        private String username;
+        private String password;
+        private Integer port;
+    }
+
+    @Data
+    public static class Jwt{
+        private String header;
+        private String access_token_secret;
+        private Long access_token_validity_in_seconds;
+        private String refresh_token_secret;
+        private Long refresh_token_validity_in_seconds;
+    }
+
+    @Bean
+    public ResourceBundleMessageSource messageSource() {
+        ResourceBundleMessageSource source= new ResourceBundleMessageSource();
+        source.setUseCodeAsDefaultMessage(true);
+        return source;
+    }
+}

--- a/src/main/java/site/moasis/monolithicbe/configuration/MailConfig.java
+++ b/src/main/java/site/moasis/monolithicbe/configuration/MailConfig.java
@@ -1,0 +1,44 @@
+package site.moasis.monolithicbe.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig{
+
+    private final AppProperties prop;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(prop.getMail().getHost());
+        javaMailSender.setUsername(prop.getMail().getUsername());
+        javaMailSender.setPassword(prop.getMail().getPassword());
+        javaMailSender.setPort(prop.getMail().getPort());
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+
+        Properties properties = new Properties();
+
+        properties.setProperty("mail.transport.protocol", prop.getMail().getProtocol());
+        properties.setProperty("mail.smtp.auth", prop.getMail().getValue());
+        properties.setProperty("mail.smtp.starttls.enable", prop.getMail().getValue());
+        properties.setProperty("mail.debug", prop.getMail().getValue());
+        properties.setProperty("mail.smtp.ssl.trust",prop.getMail().getHost());
+        properties.setProperty("mail.smtp.ssl.enable",prop.getMail().getValue());
+
+        return properties;
+    }
+}

--- a/src/main/java/site/moasis/monolithicbe/domain/useraccount/AccessTokenManager.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/useraccount/AccessTokenManager.java
@@ -1,13 +1,13 @@
 package site.moasis.monolithicbe.domain.useraccount;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import site.moasis.monolithicbe.configuration.AppProperties;
 
 @Component
 public class AccessTokenManager extends TokenManager {
-	public AccessTokenManager(@Value("${jwt.access-token-secret}") String tokenSecret,
-	                           @Value("${jwt.access-token-validity-in-seconds}") Long tokenValidityInSeconds)
+
+	public AccessTokenManager(AppProperties prop)
 	{
-		super(tokenSecret, tokenValidityInSeconds);
+		super(prop.getJwt().getAccess_token_secret(), prop.getJwt().getAccess_token_validity_in_seconds());
 	}
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/useraccount/RefreshTokenManager.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/useraccount/RefreshTokenManager.java
@@ -1,12 +1,12 @@
 package site.moasis.monolithicbe.domain.useraccount;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import site.moasis.monolithicbe.configuration.AppProperties;
 
 @Component
 public class RefreshTokenManager extends TokenManager {
-	public RefreshTokenManager(@Value("${jwt.refresh-token-secret}") String tokenSecret,
-	                           @Value("${jwt.refresh-token-validity-in-seconds}") Long tokenValidityInSeconds){
-		super(tokenSecret, tokenValidityInSeconds);
+	public RefreshTokenManager(AppProperties prop)
+	{
+		super(prop.getJwt().getAccess_token_secret(), prop.getJwt().getAccess_token_validity_in_seconds());
 	}
 }

--- a/src/main/java/site/moasis/monolithicbe/domain/useraccount/service/UserEmailService.java
+++ b/src/main/java/site/moasis/monolithicbe/domain/useraccount/service/UserEmailService.java
@@ -4,12 +4,12 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import site.moasis.monolithicbe.common.exception.BusinessException;
 import site.moasis.monolithicbe.common.exception.ErrorCode;
+import site.moasis.monolithicbe.configuration.AppProperties;
 
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,17 +22,15 @@ import static site.moasis.monolithicbe.common.message.UserMessage.*;
 public class UserEmailService {
 
     private final JavaMailSender javaMailSender;
+    private final AppProperties appProperties;
     private final ConcurrentHashMap<String, Integer> codeMap = new ConcurrentHashMap<>();
-
-    @Value("${spring.mail.username}")
-    private String origin;
 
     public void sendCode(String email) {
         int code = generateCode();
         try {
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
-            mimeMessageHelper.setFrom(new InternetAddress(origin, EMAIL_CERTIFICATION_MAIL_SENDER, "UTF-8"));
+            mimeMessageHelper.setFrom(new InternetAddress(appProperties.getMail().getUsername(), EMAIL_CERTIFICATION_MAIL_SENDER, "UTF-8"));
             mimeMessageHelper.setTo(email);
             mimeMessageHelper.setSubject(EMAIL_CERTIFICATION_MAIL_TITLE);
             mimeMessageHelper.setText(EMAIL_CERTIFICATION_MAIL_CONTENT_PREFIX + code + EMAIL_CERTIFICATION_MAIL_CONTENT_POSTFIX, true);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
+    driver-class-name: ${DRIVER_CLASS_NAME}
     url: jdbc:${DB}://${HOST}:${PORT}/${NAME}?createDatabaseIfNotExist=true
     username: ${USER}
     password: ${PASSWORD}
@@ -8,29 +8,22 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: ${DDL-AUTO}
-    database-platform: org.hibernate.dialect.MariaDB103Dialect
+    database-platform: ${DIALECT}
     properties:
       hibernate:
         jdbc:
-          time_zone: UTC
-
+          time_zone: ${TIME_ZONE}
+app:
   mail:
-    # host, port는 naver에서 정해준 값
-    host: smtp.naver.com
-    port: 465
-    # 본인 naver 계정정보 삽입
-    username: ${NAVER-MAIL-ID}
-    password: ${NAVER-MAIL-PASSWORD}
-    # 전송하기 위한 prop으로 ssl의 신뢰, 권한 등 사용허가
-    properties:
-      mail.smtp.auth: true
-      mail.smtp.ssl.enable: true
-      mail.smtp.ssl.trust: smtp.naver.com
-      
-      
-jwt:
-  header: ${HEADER_STRING}
-  access-token-secret: ${ACCESS_TOKEN_SECRET}
-  access-token-validity-in-seconds: ${ACCESS_TOKEN_EXPIRE}
-  refresh-token-secret: ${REFRESH_TOKEN_SECRET}
-  refresh-token-validity-in-seconds: ${REFRESH_TOKEN_EXPIRE}
+    protocol: ${MAIL_PROTOCOL}
+    value: ${MAIL_VALUE}
+    host: ${MAIL_HOST}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    port: ${MAIL_PORT}
+  jwt:
+    header: ${SECRET_HEADER}
+    access_token_secret: ${ACCESS_TOKEN_SECRET}
+    access_token_validity_in_seconds: ${ACCESS_TOKEN_VALIDITY_IN_SECONDS}
+    refresh_token_secret: ${REFRESH_TOKEN_SECRET}
+    refresh_token_validity_in_seconds: ${REFRESH_TOKEN_VALIDITY_IN_SECONDS}


### PR DESCRIPTION
- JavaMailSender 주입이 안되는 현상을 해결 하였으며 추가적으로 프로젝트에서 접근할 환경변수의 값을 yml의 app prefix에서 일괄적으로 관리 할 수 있도록 함.

### 문제상황

```powershell
> consider defining a bean of type 'org.springframework.mail.javamail.javamailsender' in your configuration.
```

- Bean 정의를 고려해보라는 메시지가 출력되면서 앱이 실행이 되지 않았다
- 그렇다면 JavaMailSender를 직접 Bean으로 등록 해주면 될 일이다

### UserEmailService

```java
@RequiredArgsConstructor
public class UserEmailService {

	private final JavaMailSender javaMailSender;
```

- JavaMailSender를 DI하도록 되어있다

### MailConfig

```java
@Configuration
@RequiredArgsConstructor
public class MailConfig{

	private final AppProperties prop;
	
	@Bean
	public JavaMailSender javaMailSender() {...}
	
	private Properties getMailProperties() {...}
}
```

- Bean으로 등록 해 주고 yml에 등록한 설정들을 직접 멤버변수와 properties에 적용했다

### AppProperties

```java
@Getter
@Component
@ConfigurationProperties(prefix = "app")
public class AppProperties {

	private final Mail mail =newMail();
	
	@Data
	public static classMail{
		private String protocol;
		private String value;
		private String host;
		private String username;
		private String password;
		private Integer port;
   }
}
```

- 위의 정보들을 MailConfig에 입력 해 주었다

### application-prod.yml

```yaml
app:
  mail:
    protocol: ${MAIL_PROTOCOL}
    value: ${MAIL_VALUE}
    host: ${MAIL_HOST}
    username: ${MAIL_USERNAME}
    password: ${MAIL_PASSWORD}
    port: ${MAIL_PORT}
```

- 최종적으로 환경변수를 할당해 문제를 해결했다